### PR TITLE
Add Feature to Kubeuser CLI for Fetching CA from Kubernetes Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ kubeuser list
 ```
 
 
+### fetch CA certificate and key
+
+To fetch CA crt and key, use the following command:
+
+```
+kubeuser fetch-ca --master_ip <MASTER_IP> --master_server_user <USER_NAME> --private_key_path <PATH_TO_PRIVATE_KEY>
+```

--- a/cmd/fetchCa.go
+++ b/cmd/fetchCa.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/hitham0101/kubeuser/pkg"
+	"github.com/spf13/cobra"
+)
+
+// FetchCaCmd represents the add command
+var FetchCaCmd = &cobra.Command{
+	Use:   "fetch-ca",
+	Short: "Fetcha CA key and certificate from the k8s cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// extract the flags
+		master_server_user, _ := cmd.Flags().GetString("master_server_user")
+		private_key_path, _ := cmd.Flags().GetString("private_key_path")
+		master_ip, _ := cmd.Flags().GetString("master_ip")
+
+		// Call the FetchCa function from the pkg package to fetch the CA key and certificate from the k8s cluster
+		pkg.FetchCa(master_server_user, private_key_path, master_ip)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(FetchCaCmd)
+
+	// Add flags to the subcommand
+	FetchCaCmd.Flags().String("master_server_user", "", "The username to be used to authenticate with the k8s cluster master server")
+	FetchCaCmd.Flags().String("private_key_path", "", "The path to the private key file which will be used to authenticate with the k8s cluster master server")
+	FetchCaCmd.Flags().String("master_ip", "", "The IP address of the k8s cluster master server")
+
+	// Mark the flags as required flags for the subcommand
+	err := FetchCaCmd.MarkFlagRequired("master_server_user")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = FetchCaCmd.MarkFlagRequired("private_key_path")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = FetchCaCmd.MarkFlagRequired("master_ip")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,14 @@ module github.com/hitham0101/kubeuser
 
 go 1.22.2
 
-require github.com/spf13/cobra v1.8.0
+require (
+	github.com/bramvdbogaerde/go-scp v1.4.0
+	github.com/spf13/cobra v1.8.0
+	golang.org/x/crypto v0.23.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bramvdbogaerde/go-scp v1.4.0 h1:jKMwpwCbcX1KyvDbm/PDJuXcMuNVlLGi0Q0reuzjyKY=
+github.com/bramvdbogaerde/go-scp v1.4.0/go.mod h1:on2aH5AxaFb2G0N5Vsdy6B0Ml7k9HuHSwfo1y0QzAbQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -6,5 +8,11 @@ github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
+golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.20.0 h1:VnkxpohqXaOBYJtBmEppKUG6mXpi+4O6purfc2+sMhw=
+golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/ca.go
+++ b/pkg/ca.go
@@ -1,0 +1,77 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	scp "github.com/bramvdbogaerde/go-scp"
+	"github.com/bramvdbogaerde/go-scp/auth"
+	"golang.org/x/crypto/ssh"
+)
+
+func FetchCa(user, private_key_path, master_ip string) {
+
+	master_socket := master_ip + ":22"
+
+	// Use SSH key authentication from the auth package
+	clientConfig, _ := auth.PrivateKey(user, private_key_path, ssh.InsecureIgnoreHostKey())
+
+	// Create a new SCP client
+	client := scp.NewClient(master_socket, &clientConfig)
+
+	// Connect to the remote server
+	err := client.Connect()
+	if err != nil {
+		fmt.Println("Couldn't establish a connection to the remote server ", err)
+		return
+	}
+
+	// Close client connection after the file has been copied
+	defer client.Close()
+
+	// ***************************************************************************************
+
+	// Copy ca.crt from remote master machine to local machine
+
+	// Create a local file to write to.
+	f, err := os.OpenFile("./ca.crt", os.O_RDWR|os.O_CREATE, 0777)
+	if err != nil {
+		fmt.Println("Couldn't create the ca.crt file")
+	}
+
+	defer f.Close()
+
+	// Copy the file from the remote server to the local file
+	err = client.CopyFromRemote(context.Background(), f, "/etc/kubernetes/ssl/ca.crt")
+	if err != nil {
+		fmt.Printf("Copy failed from remote: %s", err.Error())
+		os.Remove("./ca.crt")
+		os.Exit(1)
+	}
+
+	fmt.Println("ca.crt copied successfully")
+
+	// ***************************************************************************************
+
+	// Copy ca.key from remote master machine to local machine
+
+	// Create a local file to write to.
+	f, err = os.OpenFile("./ca.key", os.O_RDWR|os.O_CREATE, 0777)
+	if err != nil {
+		fmt.Println("Couldn't create the ca.key file")
+	}
+
+	defer f.Close()
+
+	// Copy the file from the remote server to the local file
+	err = client.CopyFromRemote(context.Background(), f, "/etc/kubernetes/ssl/ca.key")
+	if err != nil {
+		fmt.Printf("Copy failed from remote: %s", err.Error())
+		os.Remove("./ca.key")
+		os.Exit(1)
+	}
+
+	fmt.Println("ca.key copied successfully")
+
+}


### PR DESCRIPTION
This pull request introduces a crucial enhancement to the Kubeuser CLI tool, enabling it to fetch the CA certificate from the Kubernetes cluster. This functionality is essential for generating new user certificates, as it provides the necessary CA information required for certificate signing.

**Changes Made:**
Implemented a new command fetch-ca in the Kubeuser CLI tool.
Added functionality to retrieve the CA certificate from the Kubernetes cluster.
Updated documentation and usage instructions to reflect the new feature.
